### PR TITLE
Don't set ZF on MUL/MULU operations on NEC V20/V30

### DIFF
--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -1451,9 +1451,7 @@ set_co_mul(int bits, int carry)
 {
     set_cf(carry);
     set_of(carry);
-    /* NOTE: When implementing the V20, care should be taken to not change
-	     the zero flag. */
-    set_zf_ex(!carry);
+    if (!is_nec) set_zf_ex(!carry);
     if (!carry)
 	wait(1, 0);
 }


### PR DESCRIPTION
Summary
=======
Don't set ZF on MUL/MULU operations on NEC V20/V30.

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
