### PR TITLE
Implement immediate IMUL operands

### DIFF
--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -1739,6 +1739,22 @@ execx86(int cycs)
 			BP = pop();
 			break;
 		}
+		case 0x62: /* BOUND r/m */
+		{
+			uint16_t oldpc = cpu_state.oldpc;
+			uint16_t lowbound = 0, highbound = 0;
+			uint16_t regval = 0;
+			do_mod_rm();
+
+			lowbound = readmemw(easeg, cpu_state.eaaddr);
+			highbound = readmemw(easeg, cpu_state.eaaddr + 2);
+			regval = get_reg(cpu_reg);
+			if (lowbound > regval || highbound < regval) {
+				cpu_state.pc = cpu_state.oldpc;
+				interrupt(5);
+			}
+			break;
+		}
 		case 0xC0: case 0xC1: /*rot imm8 */
 			bits = 8 << (opcode & 1);
 			do_mod_rm();

--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -1720,6 +1720,8 @@ execx86(int cycs)
 			cpu_src = pfq_fetchb();
 
 			wait((cpu_mod != 3) ? 9 : 6, 0);
+
+			if (!is_nec) cpu_src &= 0x1F;
 			while (cpu_src != 0) {
 				cpu_dest = cpu_data;
 				oldc = cpu_state.flags & C_FLAG;
@@ -2841,6 +2843,7 @@ execx86(int cycs)
 				cpu_src = CL;
 				wait((cpu_mod != 3) ? 9 : 6, 0);
 			}
+			if (is186 && !is_nec) cpu_src &= 0x1F;
 			while (cpu_src != 0) {
 				cpu_dest = cpu_data;
 				oldc = cpu_state.flags & C_FLAG;

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -373,7 +373,7 @@ cpu_set(void)
     unmask_a20_in_smm = 0;
 
     CPUID        = cpu_s->cpuid_model;
-    is8086       = (cpu_s->cpu_type > CPU_8088) && !(cpu_s->cpu_type == CPU_V20) && !(cpu_s->cpu_type == CPU_V30);
+    is8086       = (cpu_s->cpu_type > CPU_8088) && !(cpu_s->cpu_type == CPU_V20);
     is_nec       = (cpu_s->cpu_type == CPU_V20) || (cpu_s->cpu_type == CPU_V30);
     is186        = (cpu_s->cpu_type == CPU_186) || (cpu_s->cpu_type == CPU_188) || (cpu_s->cpu_type == CPU_V20) || (cpu_s->cpu_type == CPU_V30);
     is286        = (cpu_s->cpu_type >= CPU_286);


### PR DESCRIPTION
Summary
=======
Implement immediate IMUL operands.

Implement PUSH segment underflow behaviour on SP = 1 values for 8018x.

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
