### PR TITLE
i8080 registers are now proper structs

### DIFF
--- a/src/include/86box/i8080.h
+++ b/src/include/86box/i8080.h
@@ -19,22 +19,22 @@ typedef struct i8080
 {
     union { 
         uint16_t af; /* Intended in case we also go for μPD9002 emulation, which also has a Z80 emulation mode. */
-        uint8_t a, flags;
+        struct { uint8_t a, flags; };
     };
     union
     {
         uint16_t bc;
-        uint8_t b, c;
+        struct { uint8_t b, c; };
     };
     union
     {
         uint16_t de;
-        uint8_t d, e;
+        struct { uint8_t d, e; };
     };
     union
     {
         uint16_t hl;
-        uint8_t h, l;
+        struct { uint8_t h, l; };
     };
     uint16_t pc, sp;
 } i8080;


### PR DESCRIPTION
Summary
=======
i8080 registers are now proper structs

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
