### PR TITLE
libslirp: Build fix for macos

### DIFF
--- a/src/network/slirp/CMakeLists.txt
+++ b/src/network/slirp/CMakeLists.txt
@@ -26,7 +26,7 @@ if(WIN32)
 endif()
 
 if(APPLE)
-    target_link_libraries(resolv)
+    target_link_libraries(slirp resolv)
 endif()
 
 # tinyglib conflicts with the real GLib used by Qt, let's just be safe


### PR DESCRIPTION
Summary
=======
Small fix for libslirp on macOS. There was a missing field in the cmake link command.

