### PR TITLE
Add option on Linux to select and use host serial ports

### DIFF
--- a/src/include/86box/device.h
+++ b/src/include/86box/device.h
@@ -54,6 +54,7 @@
 #define CONFIG_MAC       9
 #define CONFIG_MIDI_IN   10
 #define CONFIG_BIOS      11
+#define CONFIG_SERPORT   12
 
 enum {
     DEVICE_PCJR = 2,      /* requires an IBM PCjr */

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -53,7 +53,7 @@ typedef struct serial_s {
         dat, int_status, scratch, fcr,
         irq, type, inst, transmit_enabled,
         fifo_enabled, rcvr_fifo_len, bits, data_bits,
-        baud_cycles, rcvr_fifo_full, txsr, pad;
+        baud_cycles, rcvr_fifo_full, txsr, pad, msr_set;
 
     uint16_t dlab, base_address;
 
@@ -93,9 +93,11 @@ extern void      serial_set_next_inst(int ni);
 extern void      serial_standalone_init(void);
 extern void      serial_set_clock_src(serial_t *dev, double clock_src);
 extern void      serial_reset_port(serial_t *dev);
+extern void      serial_device_timeout(void* priv);
 
 extern void      serial_set_cts(serial_t *dev, uint8_t enabled);
 extern void      serial_set_dsr(serial_t *dev, uint8_t enabled);
+extern void      serial_set_dcd(serial_t *dev, uint8_t enabled);
 
 extern const device_t ns8250_device;
 extern const device_t ns8250_pcjr_device;

--- a/src/include/86box/serial_passthrough.h
+++ b/src/include/86box/serial_passthrough.h
@@ -28,11 +28,11 @@
 #include <86box/serial.h>
 
 
-#define SERPT_MODES_MAX 2
-
 enum serial_passthrough_mode {
         SERPT_MODE_VCON,
-	SERPT_MODE_TCP
+	SERPT_MODE_TCP,
+        SERPT_MODE_HOSTSER,
+        SERPT_MODES_MAX,
 };
 
 extern const char *serpt_mode_names[SERPT_MODES_MAX];
@@ -43,11 +43,14 @@ typedef struct serial_passthrough_s {
         pc_timer_t serial_to_host_timer;
         serial_t *serial;
         uint32_t baudrate;
+        uint8_t bits, data_bits;
         uint8_t port;
         uint8_t data;
-        char slave_pt[32];      /* used for pseudo term name of slave side */ 
-        int master_fd;          /* file desc for master pseudo terminal or
-                                 * socket or alike */
+        char slave_pt[32];           /* used for pseudo term name of slave side */ 
+        int master_fd;               /* file desc for master pseudo terminal or
+                                      * socket or alike */
+        char host_serial_path[1024]; /* Path to TTY/host serial port on the host */
+        void* backend_priv;          /* Private platform backend data */
 } serial_passthrough_t;
 
 extern bool serial_passthrough_enabled[SERIAL_MAX];

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -27,6 +27,7 @@
 #include <QCheckBox>
 #include <QFrame>
 #include <QLabel>
+#include <QDir>
 
 extern "C" {
 #include <86box/86box.h>
@@ -40,6 +41,10 @@ extern "C" {
 
 #include "qt_filefield.hpp"
 #include "qt_models_common.hpp"
+#ifdef Q_OS_LINUX
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#endif
 
 DeviceConfig::DeviceConfig(QWidget *parent)
     : QDialog(parent)
@@ -51,6 +56,25 @@ DeviceConfig::DeviceConfig(QWidget *parent)
 DeviceConfig::~DeviceConfig()
 {
     delete ui;
+}
+
+static QStringList
+EnumerateSerialDevices() {
+    QStringList serialDevices, ttyEntries;
+    QByteArray devstr(1024, 0);
+#ifdef Q_OS_LINUX
+    QDir class_dir("/sys/class/tty/");
+    QDir dev_dir("/dev/");
+    ttyEntries = class_dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System, QDir::SortFlag::Name);
+    for (int i = 0; i < ttyEntries.size(); i++) {
+        if (class_dir.exists(ttyEntries[i] + "/device/driver/") && dev_dir.exists(ttyEntries[i])
+        && QFileInfo(dev_dir.canonicalPath() + '/' + ttyEntries[i]).isReadable()
+        && QFileInfo(dev_dir.canonicalPath() + '/' + ttyEntries[i]).isWritable()) {
+            serialDevices.push_back("/dev/" + ttyEntries[i]);
+        }
+    }
+#endif
+    return serialDevices;
 }
 
 void
@@ -205,6 +229,27 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                     dc.ui->formLayout->addRow(config->description, fileField);
                     break;
                 }
+            case CONFIG_SERPORT:
+                {
+                    auto *cbox = new QComboBox();
+                    cbox->setObjectName(config->name);
+                    auto *model         = cbox->model();
+                    int   currentIndex  = 0;
+                    auto  serialDevices = EnumerateSerialDevices();
+                    char* selected      = config_get_string(device_context.name, const_cast<char *>(config->name), const_cast<char *>(config->default_string));
+                    
+                    Models::AddEntry(model, "None", -1);
+                    for (int i = 0; i < serialDevices.size(); i++) {
+                        int row = Models::AddEntry(model, serialDevices[i], i);
+                        if (selected == serialDevices[i]) {
+                            currentIndex = row;
+                        }
+                    }
+
+                    dc.ui->formLayout->addRow(config->description, cbox);
+                    cbox->setCurrentIndex(currentIndex);
+                    break;
+                }
         }
         ++config;
     }
@@ -234,6 +279,14 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                         auto *cbox = dc.findChild<QComboBox *>(config->name);
                         int   idx  = cbox->currentData().toInt();
                         config_set_string(device_context.name, const_cast<char *>(config->name), const_cast<char *>(config->bios[idx].internal_name));
+                        break;
+                    }
+                case CONFIG_SERPORT:
+                    {
+                        auto *cbox  = dc.findChild<QComboBox *>(config->name);
+                        auto  path  = cbox->currentText().toUtf8();
+                        if (path == "None") path = "";
+                        config_set_string(device_context.name, const_cast<char *>(config->name), path);
                         break;
                     }
                 case CONFIG_HEX16:


### PR DESCRIPTION
Summary
=======
Add option on Linux to select and use host serial ports

References
==========
None.
