### PR TITLE
serial_passthrough: Sync host serial port data and stop bits with the guest

### DIFF
--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -520,6 +520,9 @@ serial_write(uint16_t addr, uint8_t val, void *p)
 
                 serial_transmit_period(dev);
                 serial_update_speed(dev);
+
+                if (dev->sd->lcr_callback)
+                    dev->sd->lcr_callback(dev, dev->sd->priv, dev->lcr);
             }
             break;
         case 4:
@@ -709,6 +712,7 @@ serial_attach(int port,
     sd->rcr_callback             = rcr_callback;
     sd->dev_write                = dev_write;
     sd->transmit_period_callback = NULL;
+    sd->lcr_callback             = NULL;
     sd->priv                     = priv;
 
     return sd->serial;
@@ -719,6 +723,7 @@ serial_attach_ex(int port,
               void (*rcr_callback)(struct serial_s *serial, void *p),
               void (*dev_write)(struct serial_s *serial, void *p, uint8_t data),
               void (*transmit_period_callback)(struct serial_s *serial, void *p, double transmit_period),
+              void (*lcr_callback)(struct serial_s *serial, void *p, uint8_t data_bits),
               void *priv)
 {
     serial_device_t *sd = &serial_devices[port];
@@ -726,6 +731,7 @@ serial_attach_ex(int port,
     sd->rcr_callback             = rcr_callback;
     sd->dev_write                = dev_write;
     sd->transmit_period_callback = transmit_period_callback;
+    sd->lcr_callback             = lcr_callback;
     sd->priv                     = priv;
 
     return sd->serial;

--- a/src/device/serial_passthrough.c
+++ b/src/device/serial_passthrough.c
@@ -150,6 +150,18 @@ serial_passthrough_transmit_period(serial_t *serial, void *p, double transmit_pe
     plat_serpt_set_params(dev);
 }
 
+void
+serial_passthrough_lcr_callback(serial_t *serial, void *p, uint8_t lcr)
+{
+    serial_passthrough_t *dev = (serial_passthrough_t *) p;
+
+    if (dev->mode != SERPT_MODE_HOSTSER) return;
+    dev->bits = serial->bits;
+    dev->data_bits = ((lcr & 0x03) + 5);
+    serial_passthrough_speed_changed(p);
+    plat_serpt_set_params(dev);
+}
+
 /* Initialize the device for use by the user. */
 static void *
 serial_passthrough_dev_init(const device_t *info)
@@ -166,7 +178,7 @@ serial_passthrough_dev_init(const device_t *info)
 
     /* Attach passthrough device to a COM port */
     dev->serial = serial_attach_ex(dev->port, serial_passthrough_rcr_cb,
-                                serial_passthrough_write, serial_passthrough_transmit_period, dev);
+                                serial_passthrough_write, serial_passthrough_transmit_period, serial_passthrough_lcr_callback, dev);
 
     strncpy(dev->host_serial_path, device_get_config_string("host_serial_path"), 1024);
 

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -70,6 +70,7 @@ typedef struct serial_s {
 typedef struct serial_device_s {
     void (*rcr_callback)(struct serial_s *serial, void *p);
     void (*dev_write)(struct serial_s *serial, void *p, uint8_t data);
+    void (*lcr_callback)(struct serial_s *serial, void *p, uint8_t lcr);
     void (*transmit_period_callback)(struct serial_s *serial, void *p, double transmit_period);
     void     *priv;
     serial_t *serial;
@@ -89,6 +90,7 @@ extern serial_t *serial_attach_ex(int port,
                                void (*rcr_callback)(struct serial_s *serial, void *p),
                                void (*dev_write)(struct serial_s *serial, void *p, uint8_t data),
                                void (*transmit_period_callback)(struct serial_s *serial, void *p, double transmit_period),
+                               void (*lcr_callback)(struct serial_s *serial, void *p, uint8_t data_bits),
                                void *priv);
 extern void      serial_remove(serial_t *dev);
 extern void      serial_set_type(serial_t *dev, int type);

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -142,6 +142,24 @@ plat_serpt_set_params(void *p)
                 BAUDRATE_RANGE(dev->baudrate, 57600, 115200, B57600);
                 BAUDRATE_RANGE(dev->baudrate, 115200, 0xFFFFFFFF, B115200);
 
+                term_attr.c_cflag &= CSIZE;
+                switch (dev->data_bits) {
+                        case 8:
+                        default:
+                                term_attr.c_cflag |= CS8;
+                                break;
+                        case 7:
+                                term_attr.c_cflag |= CS7;
+                                break;
+                        case 6:
+                                term_attr.c_cflag |= CS6;
+                                break;
+                        case 5:
+                                term_attr.c_cflag |= CS5;
+                                break;
+                }
+                term_attr.c_cflag &= CSTOPB;
+                if (dev->serial->lcr & 0x04) term_attr.c_cflag |= CSTOPB;
                 tcsetattr(dev->master_fd, TCSANOW, &term_attr);
 #undef BAUDRATE_RANGE
         }

--- a/src/win/win_serial_passthrough.c
+++ b/src/win/win_serial_passthrough.c
@@ -97,6 +97,9 @@ plat_serpt_set_params(void *p)
                 BAUDRATE_RANGE(dev->baudrate, 57600, 115200);
                 BAUDRATE_RANGE(dev->baudrate, 115200, 0xFFFFFFFF);
 
+                serialattr.ByteSize = dev->data_bits;
+                serialattr.StopBits = (dev->serial->lcr & 0x04) ? TWOSTOPBITS : ONESTOPBIT;
+
                 SetCommState((HANDLE)dev->master_fd, &serialattr);
 #undef BAUDRATE_RANGE
         }


### PR DESCRIPTION
Summary
=======
serial_passthrough: Sync host serial port data and stop bits with the guest

References
==========
None.
