### PR TITLE
serial_passthrough: Sync parity settings with the host serial port

### DIFF
--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -507,7 +507,7 @@ serial_write(uint16_t addr, uint8_t val, void *p)
         case 3:
             old      = dev->lcr;
             dev->lcr = val;
-            if ((old ^ val) & 0x0f) {
+            if ((old ^ val) & 0x3f) {
                 /* Data bits + start bit. */
                 dev->bits = ((dev->lcr & 0x03) + 5) + 1;
                 /* Stop bits. */

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -160,6 +160,18 @@ plat_serpt_set_params(void *p)
                 }
                 term_attr.c_cflag &= CSTOPB;
                 if (dev->serial->lcr & 0x04) term_attr.c_cflag |= CSTOPB;
+#ifdef __APPLE__
+                term_attr.c_cflag &= PARENB | PARODD;
+#else
+                term_attr.c_cflag &= PARENB | PARODD | CMSPAR;
+#endif
+                if (dev->serial->lcr & 0x08) {
+                        term_attr.c_cflag |= PARENB;
+                        if (!(dev->serial->lcr & 0x10)) term_attr.c_cflag |= PARODD;
+#ifndef __APPLE__
+                        if ((dev->serial->lcr & 0x20)) term_attr.c_cflag |= CMSPAR;
+#endif
+                }
                 tcsetattr(dev->master_fd, TCSANOW, &term_attr);
 #undef BAUDRATE_RANGE
         }


### PR DESCRIPTION
Summary
=======
serial_passthrough: Sync parity settings with the host serial port

References
==========
None.
