### PR TITLE
serial: FIFO mode no longer returns extraneous characters

### DIFF
--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -601,11 +601,15 @@ serial_read(uint16_t addr, void *p)
 
                 ret                 = dev->rcvr_fifo[0];
                 dev->rcvr_fifo_full = 0;
+
+                for (i = 1; i < 16; i++)
+                    dev->rcvr_fifo[i - 1] = dev->rcvr_fifo[i];
+
+                dev->rcvr_fifo_pos--;
+
                 if (dev->rcvr_fifo_pos > 0) {
-                    for (i = 1; i < 16; i++)
-                        dev->rcvr_fifo[i - 1] = dev->rcvr_fifo[i];
                     serial_log("FIFO position %i: read %02X, next %02X\n", dev->rcvr_fifo_pos, ret, dev->rcvr_fifo[0]);
-                    dev->rcvr_fifo_pos--;
+
                     /* At least one byte remains to be read, start the timeout
                        timer so that a timeout is indicated in case of no read. */
                     timer_on_auto(&dev->timeout_timer, 4.0 * dev->bits * dev->transmit_period);

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -163,7 +163,7 @@ write_fifo(serial_t *dev, uint8_t dat)
             dev->lsr |= 0x01;
             dev->int_status |= SERIAL_INT_RECEIVE;
         }
-        if (dev->rcvr_fifo_pos < 15)
+        if (dev->rcvr_fifo_pos < (dev->rcvr_fifo_len - 1))
             dev->rcvr_fifo_pos++;
         else
             dev->rcvr_fifo_full = 1;

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -93,7 +93,7 @@ serial_transmit_period(serial_t *dev)
 
     /* Bit period based on DLAB. */
     dev->transmit_period = (16000000.0 * ddlab) / dev->clock_src;
-    if (dev->sd->transmit_period_callback)
+    if (dev->sd && dev->sd->transmit_period_callback)
         dev->sd->transmit_period_callback(dev, dev->sd->priv, dev->transmit_period);
 }
 
@@ -522,13 +522,13 @@ serial_write(uint16_t addr, uint8_t val, void *p)
                 serial_transmit_period(dev);
                 serial_update_speed(dev);
 
-                if (dev->sd->lcr_callback)
+                if (dev->sd && dev->sd->lcr_callback)
                     dev->sd->lcr_callback(dev, dev->sd->priv, dev->lcr);
             }
             break;
         case 4:
             if ((val & 2) && !(dev->mctrl & 2)) {
-                if (dev->sd->rcr_callback)
+                if (dev->sd && dev->sd->rcr_callback)
                     dev->sd->rcr_callback(dev, dev->sd->priv);
             }
             if (!(val & 8) && (dev->mctrl & 8))


### PR DESCRIPTION
Summary
=======
serial: FIFO mode no longer returns extraneous characters

Fixes echo behaviour on UNIX/Linux guests using serial terminals

References
==========
None.
