### PR TITLE
IMFC: Fix audio clipping (and a compile issue)

### DIFF
--- a/src/sound/snd_imfc.cpp
+++ b/src/sound/snd_imfc.cpp
@@ -5138,8 +5138,8 @@ void ym2151_device::sound_stream_update(const uint16_t requested_frames, int32_t
 
 	// First, send any frames we've queued since the last callback
 	while (frames_remaining && fifo.size()) {
-		buffer[(i * 2)] += fifo.front().outl * 32767.0;
-		buffer[(i * 2) + 1] += fifo.front().outr * 32767.0;
+		buffer[(i * 2)] += fifo.front().outl * 2.0;
+		buffer[(i * 2) + 1] += fifo.front().outr * 2.0;
 		i++;
 		fifo.pop();
 		--frames_remaining;
@@ -5147,8 +5147,8 @@ void ym2151_device::sound_stream_update(const uint16_t requested_frames, int32_t
 	// If the queue's run dry, render the remainder and sync-up our time datum
 	while (frames_remaining) {
 		const auto frame = RenderFrame();
-		buffer[(i * 2)] += frame.outl * 32767.0;
-		buffer[(i * 2) + 1] += frame.outr * 32767.0;
+		buffer[(i * 2)] += frame.outl * 2.0;
+		buffer[(i * 2) + 1] += frame.outr * 2.0;
 		i++;
 		--frames_remaining;
 	}

--- a/src/sound/snd_imfc.cpp
+++ b/src/sound/snd_imfc.cpp
@@ -84,6 +84,8 @@ extern double cpuclock;
 // Enable to activate IMF_LOG calls
 #define IMFC_VERBOSE_LOGGING 0
 
+#define NDEBUG 1
+
 constexpr uint8_t AVAILABLE_MIDI_CHANNELS = 16;
 constexpr uint8_t AVAILABLE_INSTRUMENTS   = 8;
 


### PR DESCRIPTION
Summary
=======
Fix the distorted audio output on the IMFC (on Sierra games it now sounds close to DOSBox-staging's output) and define NDEBUG to avoid a compile issue.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
